### PR TITLE
Updated eslint to version 1.5.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
     "babel-core": "5.8.25",
     "babel-loader": "5.3.2",
     "classnames": "2.1.5",
-    "eslint": "1.3.1",
+    "eslint": "1.5.1",
     "mocha": "2.3.3",
     "react-addons-test-utils": "0.14.0-rc1",
     "react-dom": "0.14.0-rc1",


### PR DESCRIPTION
:rocket:

eslint just published version 1.5.1, so that’s now up to date in your `package.json`.

Check that it doesn’t break your code and release the new version of your software safe in the knowledge that it will stay in this working state.

---

[GitHub Release](https://github.com/eslint/eslint/releases/tag/v1.5.1)
- Fix: valid-jsdoc fix for param with properties (fixes #3476) (Gyandeep Singh)
- Fix: valid-jsdoc error with square braces (fixes #2270) (Gyandeep Singh)
- Upgrade: `doctrine` to 0.7.0 (fixes #3891) (Gyandeep Singh)
- Fix: `space-before-keywords` had been wrong on getters (fixes #3854) (Toru Nagashima)
- Fix: `no-dupe-args` had been wrong for nested destructure (fixes #3867) (Toru Nagashima)
- Docs: io.js is the new Node.js (thefourtheye)
- Docs: Fix method signature on working-with-rules docs (fixes #3862) (alberto)
- Docs: Add related ternary links (refs #3835) (Ian VanSchooten)
- Fix: don’t ignore config if cwd is the home dir (fixes #3846) (Mathias Schreck)
- Fix: `func-style` had been warning arrows with `this` (fixes #3819) (Toru Nagashima)
- Fix: `space-before-keywords`; allow opening curly braces (fixes #3789) (Marko Raatikka)
- Build: Fix broken .gitattributes generation (fixes #3566) (Nicholas C. Zakas)
- Build: Fix formatter docs generation (fixes #3847) (Nicholas C. Zakas)

---

The new version differs by 229 commits (ahead by 229, behind by 0).
- [63cd482](https://github.com/eslint/eslint/commit/63cd48217b3f2f79b5dfea0c70a90c83cfbd0256): 1.5.1
- [dc8a088](https://github.com/eslint/eslint/commit/dc8a0884999ce5b6ad4c540fa550d39c272c09ce): Merge pull request #3895 from eslint/issue2270
- [e93a275](https://github.com/eslint/eslint/commit/e93a2756c3b387f293771777244b2f600fcd09ac): Merge pull request #3896 from eslint/issue3476
- [28d0c4a](https://github.com/eslint/eslint/commit/28d0c4ac60279cbfc8b7955fd1f1f478b89c5118): Fix: valid-jsdoc fix for param with properties (fixes #3476)
- [4e85380](https://github.com/eslint/eslint/commit/4e85380fdb4688b6a506d00161afa64823572287): Fix: valid-jsdoc error with square braces (fixes #2270)
- [e61131a](https://github.com/eslint/eslint/commit/e61131a20407441b374841fa96896b2fe1992f9e): Merge pull request #3892 from eslint/issue3891
- [3ad8a65](https://github.com/eslint/eslint/commit/3ad8a653b5877f2fbcb57af325698f49dec80421): Upgrade: `doctrine` to 0.7.0 (fixes #3891)
- [d48ed34](https://github.com/eslint/eslint/commit/d48ed34521502155e4895ab73fc1d361a1735c86): Merge pull request #3870 from mysticatea/space-before-keywords/fix-getters-setters
- [b1a6893](https://github.com/eslint/eslint/commit/b1a68933cb43f4efe1692e8b2ac5a6a8d7c0bbb7): Fix: `space-before-keywords` had been wrong on getters (fixes #3854)
- [4216cf2](https://github.com/eslint/eslint/commit/4216cf2dbb32718327dfcd8be4678a9a6ce0a910): Merge pull request #3850 from mmrko/issue-3789
- [b5dd36c](https://github.com/eslint/eslint/commit/b5dd36cd2d06f652c17c1a86bcd9b139b9cff4a4): Merge pull request #3868 from mysticatea/no-dupe-args/fix-nested-destructuring
- [d5f519b](https://github.com/eslint/eslint/commit/d5f519b0768c0dfb3ce067de8e17011fe542a187): Fix: `no-dupe-args` had been wrong for nested destructure (fixes #3867)
- [adf5124](https://github.com/eslint/eslint/commit/adf5124de692bf7f9915b82c7351c69b61f94741): Merge pull request #3861 from eslint/issue3846
- [f299ab7](https://github.com/eslint/eslint/commit/f299ab7953dfb9092009d21c927d4874a564bf68): Merge pull request #3855 from thefourtheye/patch-1
- [8def963](https://github.com/eslint/eslint/commit/8def963dd729a4f0499c6ee3e2eab0a1c96f8e53): Docs: io.js is the new Node.js

There are 229 commits in total. See the [full diff](https://github.com/eslint/eslint/compare/24d836e8c1d07856d5f805e72c7cfba4cebf81ad...63cd48217b3f2f79b5dfea0c70a90c83cfbd0256).

---

This pull request was created by [greenkeeper.io](http://greenkeeper.io/).
It keeps your software, up to date, all the time.

<sub>
Tired of seeing this sponsor message? Upgrade to the supporter plan!
You'll also get your pull requests faster :zap:
</sub>
