### PR TITLE
noStrict: removing use strict statement from the code

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-component-starter-kit",
-  "version": "0.0.2",
+  "version": "0.0.3",
   "description": "Simple React component starter kit stuff.",
   "main": "./dist/modules/index.js",
   "scripts": {

--- a/src/YourComponent.jsx
+++ b/src/YourComponent.jsx
@@ -1,5 +1,3 @@
-'use strict';
-
 import React, { Component, PropTypes } from 'react';
 
 export default class YourComponent extends Component {

--- a/src/YourComponentTest.jsx
+++ b/src/YourComponentTest.jsx
@@ -1,5 +1,3 @@
-'use strict';
-
 import expect from 'unexpected';
 import React from 'react';
 import TestUtils from 'react-addons-test-utils';

--- a/src/index.js
+++ b/src/index.js
@@ -1,5 +1,3 @@
-'use strict';
-
 import YourComponent from './YourComponent';
 
 export default YourComponent;


### PR DESCRIPTION
According to multiple sources there is no need for `use strict` statement in ES6 code.

[StackOverflow question](http://stackoverflow.com/a/31685340/812519)
[ECMAScript 2015 Language Specification](http://www.ecma-international.org/ecma-262/6.0/#sec-strict-mode-code)
Plus transpiled ES5 code already has `use strict` statement in `dist/` folder
